### PR TITLE
Deprecation annotation was on the wrong symbol

### DIFF
--- a/instructor/introduction/src/main/kotlin/org/jetbrains/kotlinworkshop/introduction/_3Classes/_11TypeAliases.kt
+++ b/instructor/introduction/src/main/kotlin/org/jetbrains/kotlinworkshop/introduction/_3Classes/_11TypeAliases.kt
@@ -7,9 +7,9 @@ typealias CustomerName = String
 // Example of using typealias for rename with @Deprecated
 
 
-@Deprecated("BasicCustomer is now called BaseCustomer", replaceWith = ReplaceWith("BaseCustomer"))
 class BaseCustomer // before was called BasicCustomer
 
+@Deprecated("BasicCustomer is now called BaseCustomer", replaceWith = ReplaceWith("BaseCustomer"))
 typealias BasicCustomer = BaseCustomer
 
 


### PR DESCRIPTION
The compiler would warn

> 'typealias BasicCustomer = BaseCustomer' uses 'BaseCustomer', which is deprecated. BasicCustomer is now called BaseCustomer

But `BaseCustomer` is not deprecated. After the change, the warning is:

> 'typealias BasicCustomer = BaseCustomer' is deprecated. BasicCustomer is now called BaseCustomer