### PR TITLE
Max function should return the largest Int instead of the smallest

### DIFF
--- a/instructor/introduction/org/jetbrains/kotlinworkshop/introduction/_1Intro/_3Functions.kt
+++ b/instructor/introduction/org/jetbrains/kotlinworkshop/introduction/_1Intro/_3Functions.kt
@@ -1,10 +1,10 @@
 package org.jetbrains.kotlinworkshop.introduction._1Intro
 
 fun max(a: Int, b: Int): Int {
-    return if (a < b) a else b
+    return if (a > b) a else b
 }
 
-fun max2(a: Int, b: Int) = if (a < b) a else b
+fun max2(a: Int, b: Int) = if (a > b) a else b
 
 // default values for arguments
 fun sum(a: Int, b: Int, c: Int = 0) = a + b + c


### PR DESCRIPTION
Currently, the implementation of the `max` and `max2` functions return the smallest Int. This of course should be the largest.